### PR TITLE
fix: Improve credential handling robustness

### DIFF
--- a/admin/class-h-bucket-settings.php
+++ b/admin/class-h-bucket-settings.php
@@ -292,10 +292,46 @@ if ( ! class_exists( 'H_Bucket_Settings' ) ) {
                 $new_input['bucket_name'] = sanitize_text_field( $input['bucket_name'] );
             }
             if ( isset( $input['access_key'] ) ) {
-                $new_input['access_key'] = !empty($input['access_key']) ? wp_encrypt_data( sanitize_text_field( $input['access_key'] ) ) : '';
+                if ( !empty( $input['access_key'] ) ) {
+                    $encrypted_access_key = wp_encrypt_data( sanitize_text_field( $input['access_key'] ) );
+                    if ( false === $encrypted_access_key ) {
+                        if ( class_exists('\HBucket\Logger') ) {
+                            \HBucket\Logger::get_instance()->error("Failed to encrypt Access Key. WordPress encryption function failed.");
+                        } else {
+                            error_log("H Bucket Settings: Failed to encrypt Access Key.");
+                        }
+                        $new_input['access_key'] = ''; // Store empty if encryption fails
+                    } else {
+                        $new_input['access_key'] = $encrypted_access_key;
+                    }
+                } else {
+                    $new_input['access_key'] = ''; // Clear if submitted empty
+                }
+            } elseif ( isset( $this->options['access_key'] ) ) {
+                // If not in input (e.g. form section not submitted), retain existing value
+                $new_input['access_key'] = $this->options['access_key'];
             }
+
+
             if ( isset( $input['secret_key'] ) ) {
-                $new_input['secret_key'] = !empty($input['secret_key']) ? wp_encrypt_data( sanitize_text_field( $input['secret_key'] ) ) : '';
+                if ( !empty( $input['secret_key'] ) ) {
+                    $encrypted_secret_key = wp_encrypt_data( sanitize_text_field( $input['secret_key'] ) );
+                    if ( false === $encrypted_secret_key ) {
+                         if ( class_exists('\HBucket\Logger') ) {
+                            \HBucket\Logger::get_instance()->error("Failed to encrypt Secret Key. WordPress encryption function failed.");
+                        } else {
+                            error_log("H Bucket Settings: Failed to encrypt Secret Key.");
+                        }
+                        $new_input['secret_key'] = ''; // Store empty if encryption fails
+                    } else {
+                        $new_input['secret_key'] = $encrypted_secret_key;
+                    }
+                } else {
+                    $new_input['secret_key'] = ''; // Clear if submitted empty
+                }
+            } elseif ( isset( $this->options['secret_key'] ) ) {
+                // If not in input, retain existing value
+                $new_input['secret_key'] = $this->options['secret_key'];
             }
              if ( isset( $input['region'] ) ) {
                 $new_input['region'] = sanitize_text_field( $input['region'] );


### PR DESCRIPTION
This commit addresses a critical error reported to occur during the saving of Hetzner credentials. Defensive coding measures have been implemented in the settings sanitization and uploader service initialization to prevent crashes and improve error logging.

Key changes:

1.  **`admin/class-h-bucket-settings.php` (`sanitize` method):**
    *   Ensured that if `wp_encrypt_data()` fails (returns `false`) during the encryption of Access Key or Secret Key, an error is logged, and an empty string is saved for the respective key instead of `false`.
    *   Strengthened logic to retain existing saved (encrypted) credentials if the input fields are not part of the current form submission (e.g., saving a different settings tab).

2.  **`includes/class-uploader-service.php` (`__construct` method):**
    *   Added explicit checks after decrypting credentials with `wp_decrypt_data()`. If decryption fails or returns a non-string value, an error is logged, and the key is treated as empty.
    *   Ensured that the S3 client initialization is aborted if decrypted keys are effectively empty.
    *   Wrapped the `new Credentials()` instantiation in a `try-catch` block.
    *   Enhanced the `try-catch` block around `new S3Client()` to catch more specific AWS SDK exceptions (`CredentialsException`, `AwsException`) in addition to general exceptions, providing more detailed error logging.
    *   Ensured `$this->s3_client` is set to `null` if any part of the credential validation or S3 client setup fails.

These improvements aim to prevent unexpected failures during the credential management lifecycle and provide clearer diagnostics if issues arise.